### PR TITLE
Implement array type

### DIFF
--- a/frontend/ast/ast.go
+++ b/frontend/ast/ast.go
@@ -7,6 +7,7 @@ const (
 	ProgramNode             NodeType = "ProgramNode"
 	VariableDeclerationNode NodeType = "VariableDeclerationNode"
 	FunctionDeclerationNode NodeType = "FunctionDeclerationNode"
+	ArrayDeclerationNode    NodeType = "ArrayDeclerationNode"
 
 	// Expressions.
 	BinaryExprNode       NodeType = "BinaryExprNode"
@@ -59,6 +60,15 @@ type VariableDecleration struct {
 }
 
 func (v VariableDecleration) expr() {}
+
+type ArrayDecleration struct {
+	Kind       NodeType
+	Value      []Expression
+	Constant   bool
+	Identifier string
+}
+
+func (a ArrayDecleration) expr() {}
 
 type FunctionDecleration struct {
 	Kind   NodeType

--- a/frontend/ast/ast.go
+++ b/frontend/ast/ast.go
@@ -19,12 +19,13 @@ const (
 	CallExpression       NodeType = "CallExpression"
 
 	// Literals.
-	NumericLiteralNode NodeType = "NumericLiteralNode"
-	StringLiteralNode  NodeType = "StringLiteralNode"
-	BooleanLiteralNode NodeType = "BooleanLiteralNode"
-	IdentifierNode     NodeType = "IdentifierNode"
-	PropertyNode       NodeType = "PropertyNode"
-	ObjectLiteralNode  NodeType = "ObjectLiteralNode"
+	NumericLiteralNode  NodeType = "NumericLiteralNode"
+	StringLiteralNode   NodeType = "StringLiteralNode"
+	BooleanLiteralNode  NodeType = "BooleanLiteralNode"
+	IdentifierNode      NodeType = "IdentifierNode"
+	ArrayIdentifierNode NodeType = "ArrayIdentifierNode"
+	PropertyNode        NodeType = "PropertyNode"
+	ObjectLiteralNode   NodeType = "ObjectLiteralNode"
 
 	// Conditionals
 	IfNode      NodeType = "IfNode"
@@ -119,6 +120,14 @@ type Identifier struct {
 }
 
 func (i Identifier) expr() {}
+
+type ArrayIdentifier struct {
+	Kind   NodeType
+	Symbol string
+	Index  Expression
+}
+
+func (ai ArrayIdentifier) expr() {}
 
 type NumericLiteral struct {
 	Kind  NodeType

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -526,7 +526,7 @@ func parse_fn_decleration() (ast.Expression, error) {
 		body = append(body, stmt)
 	}
 
-	// End of function, expect to see the closing bracket.
+	// End of function, expect to see the closing brace.
 	_, err = expect(lexer.CloseBrace)
 	if err != nil {
 		return nil, err
@@ -550,6 +550,8 @@ Handles either:
 */
 func parse_var_decleration() (ast.Expression, error) {
 
+	// true:  const x = 10;
+	// false: let x = 10;
 	isConst := eat().Type == lexer.Const
 	identifier, err := expect(lexer.Identifier)
 	if err != nil {
@@ -581,6 +583,23 @@ func parse_var_decleration() (ast.Expression, error) {
 		return ast.Expr{}, err
 	}
 
+	// In the case of 'let x = [];', we are declaring an array.
+	if at().Type == lexer.OpenBracket {
+
+		// Eat the opening bracket.
+		eat()
+
+		fmt.Println("Array declaration found!")
+
+		// Attempt to capture all the expressions inside the array.
+		array_decleration, err := parse_array_decleration(identifier.Value, isConst)
+		if err != nil {
+			return ast.Expr{}, err
+		}
+
+		return array_decleration, nil
+	}
+
 	value, err := parse_expression()
 	if err != nil {
 		return ast.Expr{}, err
@@ -596,6 +615,53 @@ func parse_var_decleration() (ast.Expression, error) {
 	_, err = expect(lexer.EOL)
 	if err != nil {
 		return ast.Expr{}, err
+	}
+
+	return decleration, nil
+}
+
+func parse_array_decleration(identifier string, isConst bool) (ast.Expression, error) {
+
+	expressions := make([]ast.Expression, 0)
+
+	for at().Type != lexer.CloseBracket && at().Type != lexer.EOF {
+
+		value, err := parse_expression()
+		fmt.Printf("Parsing expression: %v \n", value)
+
+		if err != nil {
+			return ast.Expr{}, err
+		}
+
+		expressions = append(expressions, value)
+
+		if at().Type == lexer.CloseBracket {
+			break
+		} else {
+			_, err = expect(lexer.Comma)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// End of array body, expect to see a closing bracket.
+	_, err := expect(lexer.CloseBracket)
+	if err != nil {
+		return nil, err
+	}
+
+	// End of array decleration, expect to see an EOL.
+	_, err = expect(lexer.EOL)
+	if err != nil {
+		return nil, err
+	}
+
+	decleration := ast.ArrayDecleration{
+		Kind:       "ArrayDeclerationNode",
+		Value:      expressions,
+		Identifier: identifier,
+		Constant:   isConst,
 	}
 
 	return decleration, nil

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -589,8 +589,6 @@ func parse_var_decleration() (ast.Expression, error) {
 		// Eat the opening bracket.
 		eat()
 
-		fmt.Println("Array declaration found!")
-
 		// Attempt to capture all the expressions inside the array.
 		array_decleration, err := parse_array_decleration(identifier.Value, isConst)
 		if err != nil {
@@ -627,7 +625,6 @@ func parse_array_decleration(identifier string, isConst bool) (ast.Expression, e
 	for at().Type != lexer.CloseBracket && at().Type != lexer.EOF {
 
 		value, err := parse_expression()
-		fmt.Printf("Parsing expression: %v \n", value)
 
 		if err != nil {
 			return ast.Expr{}, err

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ func main() {
 	} else {
 
 		// REPL Mode.
+		fmt.Println("Goblin v0.1")
+
 		for {
 
 			fmt.Print("> ")

--- a/main.go
+++ b/main.go
@@ -100,12 +100,12 @@ func run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 
 	program, err := parser.ProduceAST(input)
 	if err != nil {
-		return nil, fmt.Errorf("parse error: %v\n", err.Error())
+		return nil, fmt.Errorf("parse error: %v", err.Error())
 	}
 
 	evaluation, err := runtime.Evaluate(program, env)
 	if err != nil {
-		return nil, fmt.Errorf("interpreter error: %v\n", err.Error())
+		return nil, fmt.Errorf("interpreter error: %v", err.Error())
 	}
 
 	if f, isNum := evaluation.(runtime.NativeFunction); isNum {

--- a/runtime/built-ins.go
+++ b/runtime/built-ins.go
@@ -53,6 +53,21 @@ func printHelper(arg RuntimeValue) string {
 
 		builder = fmt.Sprintf("%v", str.Value)
 
+	} else if arr, ok := arg.(ArrayValue); ok {
+
+		builder = "["
+		for i := 0; i < len(arr.Value); i++ {
+
+			val := fmt.Sprintf("%v", arr.Value[i])
+
+			builder += val
+
+			if i < len(arr.Value)-1 {
+				builder += ", "
+			}
+		}
+		builder += "]"
+
 	} else if null, ok := arg.(NullValue); ok {
 
 		builder = fmt.Sprintf("%v", null.Value)

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -31,6 +31,30 @@ func (e Environment) Declare(var_ string, value RuntimeValue, isConst bool) (Run
 	return value, nil
 }
 
+// Used to declare a new array. Includes checking for arrays that might already existing.
+func (e Environment) DeclareArray(var_ string, values []RuntimeValue, isConst bool) (RuntimeValue, error) {
+
+	_, exists := e.Variables[var_]
+
+	// If this variable is already set.
+	if exists {
+		return nil, fmt.Errorf("'%v' already defined", var_)
+	}
+
+	// Make the array object here, which contains all the RuntimeValues the user specified.
+	arr := MK_ARRAY(values)
+
+	// If not, set it.
+	e.Variables[var_] = arr
+
+	// Add our constant variable.
+	if isConst {
+		e.Constants[var_] = true
+	}
+
+	return arr, nil
+}
+
 // Used to assign values to a variable.
 func (e Environment) Assign(var_ string, value RuntimeValue) (RuntimeValue, error) {
 

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -108,6 +108,29 @@ func (e Environment) Lookup(var_ string) (RuntimeValue, error) {
 	return env.Variables[var_], nil
 }
 
+// Used in the specific case of looking up individual elements in an array.
+func (e Environment) ArrayLookup(var_ string, index int) (RuntimeValue, error) {
+
+	arr_, err := e.Lookup(var_)
+	if err != nil {
+		return nil, err
+	}
+
+	var value RuntimeValue
+	if arr, ok := arr_.(ArrayValue); ok {
+
+		// The specified index value is out of bounds!
+		if index >= len(arr.Value) {
+
+			e := fmt.Sprintf("index out of bounds for index %v \n", index)
+			return MK_STRING(e), fmt.Errorf(e)
+		}
+		value = arr.Value[index]
+	}
+
+	return value, nil
+}
+
 func (e Environment) Setup() {
 
 	e.Declare("null", MK_NULL(), true)

--- a/runtime/interpreter.go
+++ b/runtime/interpreter.go
@@ -76,6 +76,15 @@ func Evaluate(astNode ast.Expression, env Environment) (RuntimeValue, error) {
 
 		return iden, nil
 
+	} else if iden, ok := astNode.(ast.ArrayIdentifier); ok {
+
+		arr, err := eval_array_identifier(iden, env)
+		if err != nil {
+			return nil, err
+		}
+
+		return arr, nil
+
 	} else if object, ok := astNode.(ast.ObjectLiteral); ok {
 
 		obj, err := eval_object_expr(object, env)
@@ -165,6 +174,30 @@ func eval_program(prog ast.Program, env Environment) (RuntimeValue, error) {
 func eval_identifier(iden ast.Identifier, env Environment) (RuntimeValue, error) {
 
 	val, err := env.Lookup(iden.Symbol)
+	if err != nil {
+		return nil, err
+	}
+
+	return val, nil
+}
+
+// Evaluates the provided identifier.
+func eval_array_identifier(arr ast.ArrayIdentifier, env Environment) (RuntimeValue, error) {
+
+	i, err := Evaluate(arr.Index, env)
+	if err != nil {
+		return nil, err
+	}
+
+	index := 0
+
+	if num, ok := i.(NumberValue); ok {
+		index = num.Value
+	} else {
+		return nil, fmt.Errorf("array index must of of type int")
+	}
+
+	val, err := env.ArrayLookup(arr.Symbol, index)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +545,7 @@ func eval_var_decleration(dec ast.VariableDecleration, env Environment) (Runtime
 	return decleration, nil
 }
 
-// Evaluates a new array decleration.
+// Evaluates an array decleration.
 func eval_arr_decleration(arr ast.ArrayDecleration, env Environment) (RuntimeValue, error) {
 
 	values := make([]RuntimeValue, 0)

--- a/runtime/interpreter.go
+++ b/runtime/interpreter.go
@@ -76,9 +76,9 @@ func Evaluate(astNode ast.Expression, env Environment) (RuntimeValue, error) {
 
 		return iden, nil
 
-	} else if iden, ok := astNode.(ast.ArrayIdentifier); ok {
+	} else if arrIden, ok := astNode.(ast.ArrayIdentifier); ok {
 
-		arr, err := eval_array_identifier(iden, env)
+		arr, err := eval_array_identifier(arrIden, env)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/interpreter.go
+++ b/runtime/interpreter.go
@@ -112,6 +112,15 @@ func Evaluate(astNode ast.Expression, env Environment) (RuntimeValue, error) {
 
 		return varDec, nil
 
+	} else if arr, ok := astNode.(ast.ArrayDecleration); ok {
+
+		arrDec, err := eval_arr_decleration(arr, env)
+		if err != nil {
+			return nil, err
+		}
+
+		return arrDec, nil
+
 	} else if func_, ok := astNode.(ast.FunctionDecleration); ok {
 
 		fn, err := eval_function_decleration(func_, env)
@@ -496,6 +505,29 @@ func eval_var_decleration(dec ast.VariableDecleration, env Environment) (Runtime
 	}
 
 	decleration, err := env.Declare(dec.Identifier, value, dec.Constant)
+	if err != nil {
+		return nil, err
+	}
+
+	return decleration, nil
+}
+
+// Evaluates a new array decleration.
+func eval_arr_decleration(arr ast.ArrayDecleration, env Environment) (RuntimeValue, error) {
+
+	values := make([]RuntimeValue, 0)
+
+	for _, val := range arr.Value {
+
+		v, err := Evaluate(val, env)
+		if err != nil {
+			return nil, err
+		}
+
+		values = append(values, v)
+	}
+
+	decleration, err := env.DeclareArray(arr.Identifier, values, arr.Constant)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -10,6 +10,7 @@ type ValueType string
 
 const (
 	Number      ValueType = "Number"
+	Array       ValueType = "Array"
 	Null        ValueType = "Null"
 	Boolean     ValueType = "Boolean"
 	String      ValueType = "String"
@@ -44,6 +45,15 @@ type NumberValue struct {
 
 func (n NumberValue) runtime() {
 	fmt.Printf("%v\n", n.Value)
+}
+
+type ArrayValue struct {
+	Type  ValueType
+	Value []any
+}
+
+func (a ArrayValue) runtime() {
+	fmt.Printf("%v\n", a.Value)
 }
 
 type StringValue struct {
@@ -109,6 +119,27 @@ func MK_NUMBER(n int) NumberValue {
 	return NumberValue{
 		Type:  "Number",
 		Value: n,
+	}
+}
+
+func MK_ARRAY(elements []RuntimeValue) ArrayValue {
+
+	values := make([]any, 0)
+
+	for _, v := range elements {
+
+		// Need to check the actual type of the damn value...
+
+		if num, ok := v.(NumberValue); ok {
+			values = append(values, num.Value)
+		} else if num, ok := v.(StringValue); ok {
+			values = append(values, num.Value)
+		}
+	}
+
+	return ArrayValue{
+		Type:  "Array",
+		Value: values,
 	}
 }
 

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -49,7 +49,7 @@ func (n NumberValue) runtime() {
 
 type ArrayValue struct {
 	Type  ValueType
-	Value []any
+	Value []RuntimeValue
 }
 
 func (a ArrayValue) runtime() {
@@ -124,22 +124,9 @@ func MK_NUMBER(n int) NumberValue {
 
 func MK_ARRAY(elements []RuntimeValue) ArrayValue {
 
-	values := make([]any, 0)
-
-	for _, v := range elements {
-
-		// Need to check the actual type of the damn value...
-
-		if num, ok := v.(NumberValue); ok {
-			values = append(values, num.Value)
-		} else if num, ok := v.(StringValue); ok {
-			values = append(values, num.Value)
-		}
-	}
-
 	return ArrayValue{
 		Type:  "Array",
-		Value: values,
+		Value: elements,
 	}
 }
 

--- a/source/test2.gob
+++ b/source/test2.gob
@@ -1,8 +1,9 @@
-let x = [1, 2, 3, 4, 5];
+let x = [10, 34, 56, 12, 78];
 let index = 0;
+let value = 0;
 
 while(index < 5){
-    let value = x[index];
+    value = x[index];
     println(value);
-    index + 1
+    index = index + 1;
 }

--- a/source/test2.gob
+++ b/source/test2.gob
@@ -1,1 +1,3 @@
-println(0 / 0);
+let y = 10;
+let x = [1, 2, 3, 4, 5];
+println(x);

--- a/source/test2.gob
+++ b/source/test2.gob
@@ -1,3 +1,8 @@
-let y = 10;
 let x = [1, 2, 3, 4, 5];
-println(x);
+let index = 0;
+
+while(index < 5){
+    let value = x[index];
+    println(value);
+    index + 1
+}


### PR DESCRIPTION
This PR adds support for array types and indexing into the language.

To declare a new array:

`let arr = [1, 2, 3, 4];`

To index the array:

`let var = arr[2];`

Resulting in expected value: `3`.