### PR TITLE
Std lib redesign

### DIFF
--- a/frontend/ast/ast.go
+++ b/frontend/ast/ast.go
@@ -11,6 +11,9 @@ const (
 	MapDeclerationNode      NodeType = "MapDeclerationNode"
 	ShorthandOperatorNode   NodeType = "ShorthandOperatorNode" // e.g. ++, --, +=, -=, /=, *=
 
+	// Namespace and Environment.
+	NamespaceDeclerationNode NodeType = "NamespaceDeclerationNode"
+
 	// Expressions.
 	BinaryExprNode       NodeType = "BinaryExprNode"
 	AssingmentExprNode   NodeType = "AssignmentExprNode"
@@ -18,7 +21,6 @@ const (
 	UnaryExprNode        NodeType = "UnaryExprNode"
 	FuncDeclerationNode  NodeType = "FuncDeclerationNode"
 	MemberExpressionNode NodeType = "MemberExpressionNode"
-	CallExpression       NodeType = "CallExpression"
 
 	// Literals.
 	NumericLiteralNode  NodeType = "NumericLiteralNode"
@@ -91,6 +93,13 @@ type FunctionDecleration struct {
 }
 
 func (f FunctionDecleration) expr() {}
+
+type NamespaceDecleration struct {
+	Kind NodeType
+	Name string
+}
+
+func (n NamespaceDecleration) expr() {}
 
 type BinaryExpr struct {
 	Kind     NodeType

--- a/frontend/lexer/lexer.go
+++ b/frontend/lexer/lexer.go
@@ -151,6 +151,7 @@ func Tokenize(sourceCode string) []Token {
 
 	// Add in the EOF token.
 	tokens = append(tokens, token(EOF, "EOF"))
+
 	return tokens
 }
 

--- a/frontend/lexer/token.go
+++ b/frontend/lexer/token.go
@@ -58,6 +58,7 @@ const (
 	Else  TokenType = "Else"  // standard else condition
 	While TokenType = "While" // standard while loop
 	For   TokenType = "For"   // standard for loop
+	Using TokenType = "Using"
 
 	// End of Line.
 	EOL TokenType = "EOL"
@@ -74,4 +75,5 @@ var Keywords = map[string]TokenType{
 	"else":  Else,
 	"while": While,
 	"for":   For,
+	"using": Using,
 }

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -736,6 +736,11 @@ func parse_var_decleration() (ast.Expression, error) {
 		Constant:   isConst,
 	}
 
+	_, isCallExpr := decleration.Value.(ast.CallExpr)
+	if isCallExpr {
+		return decleration, nil
+	}
+
 	_, err = expect(lexer.EOL)
 	if err != nil {
 		return ast.Expr{}, err

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -129,6 +129,14 @@ func parse_statement() (ast.Expression, error) {
 		}
 
 		return while, nil
+	case lexer.Using:
+
+		using, err := parse_using_decleration()
+		if err != nil {
+			return ast.Expr{}, err
+		}
+
+		return using, nil
 	default:
 		expr, err := parse_expression()
 		if err != nil {
@@ -989,6 +997,34 @@ func parse_args_list() ([]ast.Expression, error) {
 	}
 
 	return args, nil
+}
+
+// Parses a 'using' directive.
+func parse_using_decleration() (ast.Expression, error) {
+
+	// Move past the 'using' keyword.
+	eat()
+
+	val, err := parse_statement()
+	if err != nil {
+		return nil, err
+	}
+
+	str, ok := val.(ast.StringLiteral)
+	if !ok {
+		return nil, fmt.Errorf("string type required with using directives, got %v", val)
+	}
+
+	// Always expect to see a ';' after a using directive.
+	_, err = expect(lexer.EOL)
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.NamespaceDecleration{
+		Kind: "NamespaceDecleration",
+		Name: str.Value,
+	}, nil
 }
 
 // Parses how to access member fields from an object.

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		} else {
 			// Only really want to print to console if its a statement that needs returning.
 			if result != nil {
-				r := fmt.Sprintf("%v\n", result)
+				r := fmt.Sprintf("%v", result)
 				utils.Stdout(r, env.Stdout)
 			}
 		}
@@ -95,7 +95,7 @@ func main() {
 			} else {
 				// Only really want to print to console if its a statement that needs returning.
 				if result != nil {
-					r := fmt.Sprintf("%v\n", result)
+					r := fmt.Sprintf("%v", result)
 					utils.Stdout(r, env.Stdout)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -14,9 +14,10 @@ import (
 func main() {
 
 	env := runtime.Environment{
-		Stdout:    os.Stdout, // Set the stdout as os.stdout
-		Variables: map[string]runtime.RuntimeValue{},
-		Constants: map[string]bool{},
+		Stdout:     os.Stdout, // Set the stdout as os.stdout
+		Variables:  map[string]runtime.RuntimeValue{},
+		Constants:  map[string]bool{},
+		Namespaces: map[string]runtime.Namespace{},
 	}
 
 	env.Setup()

--- a/program/run.go
+++ b/program/run.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"goblin.org/main/frontend/parser"
-	"goblin.org/main/runtime"
+	runtime "goblin.org/main/runtime"
 	"goblin.org/main/utils"
 )
 
@@ -15,8 +15,6 @@ func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %v", err.Error())
 	}
-
-	// fmt.Printf("%v \n", program)
 
 	evaluation, err := runtime.Evaluate(program, env)
 	if err != nil {

--- a/runtime/interpreter.go
+++ b/runtime/interpreter.go
@@ -728,7 +728,10 @@ func eval_call_expr(expr ast.CallExpr, env Environment) (RuntimeValue, error) {
 	if isFn {
 		// Build the function call.
 		var func_ FunctionCall = nativeFunc.Call
-		result := func_(args, env)
+		result, err := func_(args, env)
+		if err != nil {
+			return nil, err
+		}
 
 		return result, nil
 	}

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -47,6 +47,8 @@ var println FunctionCall = func(args []RuntimeValue, env Environment) RuntimeVal
 		builder += printHelper(arg)
 	}
 
+	builder += "\n"
+
 	utils.Stdout(builder, env.Stdout)
 
 	return MK_NULL()

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -29,44 +29,38 @@ var IO = Namespace{
 }
 
 // Defines the built-in method 'print'.
-// Depending on arg value type, print is handled in different ways.
+// print, a standard printing function.
 var print FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
-	builder := ""
-
-	for _, arg := range args {
-
-		builder += printHelper(arg)
+	str, err := printer(args)
+	if err != nil {
+		return nil, err
 	}
 
-	utils.Stdout(builder, env.Stdout)
+	utils.Stdout(str, env.Stdout)
 
 	return MK_NULL(), nil
 }
 
 // Defines the built-in method 'println'.
-// Same as 'print' but adds a '\n' char at the end of the output.
+// println acts the same as print, but appends a new line to the end.
 var println FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
-	builder := ""
-
-	for _, arg := range args {
-
-		builder += printHelper(arg)
+	str, err := printer(args)
+	if err != nil {
+		return nil, err
 	}
 
-	builder += "\n"
-
-	utils.Stdout(builder, env.Stdout)
+	utils.Stdout(str+"\n", env.Stdout)
 
 	return MK_NULL(), nil
 }
 
 // Defines build-in method 'printf'.
-// Printf allows for formatted statements to be printed.
+// printf allows for formatted statements to be printed.
 var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
-	s, err := printer(args)
+	s, err := printerFormatter(args)
 	if err != nil {
 		return nil, err
 	}
@@ -78,10 +72,10 @@ var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVal
 }
 
 // Defines build-in method 'printf'.
-// Printf allows for formatted statements to be printed.
+// sprintf allows for formatted statements to be printed.
 var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
-	s, err := printer(args)
+	s, err := printerFormatter(args)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +84,7 @@ var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVa
 }
 
 // Helper function for printf, sprintf
-func printer(args []RuntimeValue) (string, error) {
+func printerFormatter(args []RuntimeValue) (string, error) {
 
 	formattedString, isStr := args[0].(StringValue)
 	arguments := args[1:]
@@ -133,6 +127,18 @@ func printer(args []RuntimeValue) (string, error) {
 		} else { // If the current character is not '%', print it literally
 			builder += fmt.Sprintf("%c", formattedString.Value[i])
 		}
+	}
+
+	return builder, nil
+}
+
+func printer(args []RuntimeValue) (string, error) {
+
+	builder := ""
+
+	for _, arg := range args {
+
+		builder += printHelper(arg)
 	}
 
 	return builder, nil

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -6,9 +6,23 @@ import (
 	"goblin.org/main/utils"
 )
 
+var IO = Namespace{
+	Name: "io",
+	Functions: map[string]NativeFunction{
+		"print": {
+			Type: "NativeFn",
+			Call: print,
+		},
+		"println": {
+			Type: "NativeFn",
+			Call: println,
+		},
+	},
+}
+
 // Defines the built-in method 'print'.
 // Depending on arg value type, print is handled in different ways.
-var Print FunctionCall = func(args []RuntimeValue, env Environment) RuntimeValue {
+var print FunctionCall = func(args []RuntimeValue, env Environment) RuntimeValue {
 
 	builder := ""
 
@@ -24,7 +38,7 @@ var Print FunctionCall = func(args []RuntimeValue, env Environment) RuntimeValue
 
 // Defines the built-in method 'println'.
 // Same as 'print' but adds a '\n' char at the end of the output.
-var Println FunctionCall = func(args []RuntimeValue, env Environment) RuntimeValue {
+var println FunctionCall = func(args []RuntimeValue, env Environment) RuntimeValue {
 
 	builder := ""
 

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -87,7 +87,7 @@ type ObjectVal struct {
 
 func (o ObjectVal) runtime() {}
 
-type FunctionCall func(args []RuntimeValue, env Environment) RuntimeValue
+type FunctionCall func(args []RuntimeValue, env Environment) (RuntimeValue, error)
 
 type NativeFunction struct {
 	Type ValueType

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -179,3 +179,10 @@ func MK_NATIVE_FN(call FunctionCall) NativeFunction {
 		Call: call,
 	}
 }
+
+type Namespace struct {
+	Name      string
+	Functions map[string]NativeFunction
+}
+
+func (n Namespace) runtime() {}

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,0 +1,2 @@
+using "io";
+io.print("Hello, World!");

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,3 +1,4 @@
 using "io";
-io.println("Hello, World!");
-io.print("Hello, World!");
+
+let x = io.sprintf("Hello, %v", "World");
+io.println(x);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,2 +1,3 @@
 using "io";
+io.println("Hello, World!");
 io.print("Hello, World!");

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -17,10 +17,12 @@ func TestSimpleArray(t *testing.T) {
 		want        string
 		throwsError bool
 	}{
-		{`let arr = [1, 2, 3, 4, 5];
-		println(arr[2]);`, "3\n", false},
-		{`let arrr = [1, 2, 3, 4, 5];
-		println(arrr[6]);`, "interpreter error: index out of bounds for index 6", true},
+		{`using "io";
+		let arr = [1, 2, 3, 4, 5];
+		io.println(arr[2]);`, "3\n", false},
+		{`using "io";
+		let arrr = [1, 2, 3, 4, 5];
+		io.println(arrr[6]);`, "interpreter error: index out of bounds for index 6", true},
 	}
 
 	for _, tt := range tests {

--- a/tests/fn_test.go
+++ b/tests/fn_test.go
@@ -17,18 +17,21 @@ func TestFunctions(t *testing.T) {
 		want        string
 		throwsError bool
 	}{
-		{`fn Print() {
-			println("Hello, World");
+		{`using "io";
+		fn Print() {
+			io.println("Hello, World");
 		}
 		Print();`, "Hello, World\n", false},
-		{`fn testPrint(a, b){
+		{`using "io";
+		fn testPrint(a, b){
 			let x = a + b;
-			println(x);
+			io.println(x);
 		}
 		testPrint(1, 3);`, "4\n", false},
-		{`fn Adder(a, b, c){
+		{`using "io";
+		fn Adder(a, b, c){
 			let x = a + b;
-			println(x);
+			io.println(x);
 		}
 		Adder(1, 3);`, "interpreter error: incorrect number of params specified for fn Adder, got 2 want 3", true},
 	}

--- a/tests/for_test.go
+++ b/tests/for_test.go
@@ -17,22 +17,27 @@ func TestForLoop(t *testing.T) {
 		want        string
 		throwsError bool
 	}{
-		{`for(let i = 0; i < 5; i++;){
-			println(i);
-		}`, "0\n1\n2\n3\n4\n", false},
-		{`for(let i = 5; i > 0; i--;){
-			println(i);
-		}`, "5\n4\n3\n2\n1\n", false},
-		{`let arr = [1, 2, 3, 4, 5];
+		{`using "io";
 		for(let i = 0; i < 5; i++;){
-			println(arr[i]);
+			io.println(i);
+		}`, "0\n1\n2\n3\n4\n", false},
+		{`using "io";
+		for(let i = 5; i > 0; i--;){
+			io.println(i);
+		}`, "5\n4\n3\n2\n1\n", false},
+		{`using "io";
+		let arr = [1, 2, 3, 4, 5];
+		for(let i = 0; i < 5; i++;){
+			io.println(arr[i]);
 		}`, "1\n2\n3\n4\n5\n", false},
-		{`let arrr = ["foo", "bar", "foobar"];
+		{`using "io";
+		let arrr = ["foo", "bar", "foobar"];
 		for(let i = 0; i < 3; i++;){
 			let val = arrr[i];
-			println(val);
+			io.println(val);
 		}`, "foo\nbar\nfoobar\n", false},
-		{`let arrrr = ["foo", "bar", "foobar"];
+		{`using "io";
+		let arrrr = ["foo", "bar", "foobar"];
 		let map = {
 			"foo": 10,
 			"bar": 20,
@@ -42,11 +47,12 @@ func TestForLoop(t *testing.T) {
 		for(let i = 0; i < 3; i++;){
 			let key = arrrr[i];
 			let val = map[key];
-			println(val);
+			io.println(val);
 		}`, "10\n20\n30\n", false},
-		{`let smallArray = [1, 2];
+		{`using "io";
+		let smallArray = [1, 2];
 		for (let i = 2; i < 3; i++;){
-			println(smallArray[i]);
+			io.println(smallArray[i]);
 		}`, "interpreter error: index out of bounds for index 2", true},
 	}
 

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -17,6 +17,7 @@ func HarnessSetup() {
 	env.Stdout = &output
 	env.Variables = map[string]runtime.RuntimeValue{}
 	env.Constants = map[string]bool{}
+	env.Namespaces = map[string]runtime.Namespace{}
 
 	env.Setup()
 }

--- a/tests/if_test.go
+++ b/tests/if_test.go
@@ -16,20 +16,24 @@ func TestSimpleIfCondition(t *testing.T) {
 		source string
 		want   string
 	}{
-		{`if (10 > 5){
-			println(10);
+		{`using "io";
+		if (10 > 5){
+			io.println(10);
 		}`, "10\n"},
-		{`if (10 < 20){
-			println(11);
+		{`using "io";
+		if (10 < 20){
+			io.println(11);
 		}`, "11\n"},
-		{`if (10 == 10){
-			println(10);
+		{`using "io";
+		if (10 == 10){
+			io.println(10);
 		}`, "10\n"},
-		{`if (5 > 10){
-			println(5);
+		{`using "io";
+		if (5 > 10){
+			io.println(5);
 		}
 		else {
-			println(10);
+			io.println(10);
 		}`, "10\n"},
 	}
 

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -195,3 +195,48 @@ func TestPrintf(t *testing.T) {
 		})
 	}
 }
+
+func TestSPrintf(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		let i = io.sprintf("Hello, %v", "World");
+		io.print(i);`, "Hello, World", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"goblin.org/main/program"
+)
+
+func TestIO(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		io.println("Hello, World");`, "Hello, World\n", false},
+		{`using "io";
+		io.print("Hello, World");`, "Hello, World", false},
+		{`using "io";
+		io.print(12);`, "12", false},
+		{`using "io";
+		let arr = [1, 2, 3];
+		io.print(arr);`, "[1, 2, 3]", false},
+		{`using "io";
+		let map = {
+			"one": 1,
+			"two": 2,
+			"three": 3,
+		};
+		io.print(map);`, "{'one': 1, 'two': 2, 'three': 3}", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -7,7 +7,78 @@ import (
 	"goblin.org/main/program"
 )
 
-func TestIO(t *testing.T) {
+func TestPrint(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		io.print("Hello, World");`, "Hello, World", false},
+		{`using "io";
+		io.print(12);`, "12", false},
+		{`using "io";
+		let arr = [1, 2, 3];
+		io.print(arr);`, "[1, 2, 3]", false},
+		{`using "io";
+		fn printer(){
+			io.print("Hello");
+		}
+		printer();`, "Hello", false},
+		{`using "io";
+		fn anotherPrinter(var){
+			io.print(var);
+		}
+		anotherPrinter("Hello");`, "Hello", false},
+		{`using "io";
+		let keys = ["one", "two", "three"];
+		let map = {
+			"one": 1,
+			"two": 2,
+			"three": 3,
+		};
+
+		for(let i = 0; i < 3; i++;){
+
+			io.print(map[keys[i]]);
+		}`, "123", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}
+
+func TestPrintln(t *testing.T) {
 
 	// Setup the program env.
 	HarnessSetup()
@@ -20,19 +91,79 @@ func TestIO(t *testing.T) {
 		{`using "io";
 		io.println("Hello, World");`, "Hello, World\n", false},
 		{`using "io";
-		io.print("Hello, World");`, "Hello, World", false},
-		{`using "io";
-		io.print(12);`, "12", false},
+		io.println(12);`, "12\n", false},
 		{`using "io";
 		let arr = [1, 2, 3];
-		io.print(arr);`, "[1, 2, 3]", false},
+		io.println(arr);`, "[1, 2, 3]\n", false},
 		{`using "io";
+		fn printer(){
+			io.println("Hello");
+		}
+		printer();`, "Hello\n", false},
+		{`using "io";
+		fn anotherPrinter(var){
+			io.println(var);
+		}
+		anotherPrinter("Hello");`, "Hello\n", false},
+		{`using "io";
+		let keys = ["one", "two", "three"];
 		let map = {
 			"one": 1,
 			"two": 2,
 			"three": 3,
 		};
-		io.print(map);`, "{'one': 1, 'two': 2, 'three': 3}", false},
+
+		for(let i = 0; i < 3; i++;){
+
+			io.println(map[keys[i]]);
+		}`, "1\n2\n3\n", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}
+
+func TestPrintf(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		io.printf("Hello, %v", "World");`, "Hello, World", false},
+		{`using "io";
+		let arr = [1, 2, 3];
+		io.printf("One: %v", arr[0]);`, "One: 1", false},
 	}
 
 	for _, tt := range tests {

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -17,16 +17,18 @@ func TestSimpleMap(t *testing.T) {
 		want        string
 		throwsError bool
 	}{
-		{`let map = {
+		{`using "io";
+		let map = {
 			"foo": 10,
 			"bar": 20,
 		};
-		println(map["foo"]);`, "10\n", false},
-		{`let mapp = {
+		io.println(map["foo"]);`, "10\n", false},
+		{`using "io";
+		let mapp = {
 			"foo": 10,
 			"bar": 20,
 		};
-		println(mapp["baz"]);`, "interpreter error: key `{String baz}` does not exist for map: mapp", true},
+		io.println(mapp["baz"]);`, "interpreter error: key `{String baz}` does not exist for map: mapp", true},
 	}
 
 	for _, tt := range tests {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -16,27 +16,34 @@ func TestOperators(t *testing.T) {
 		source string
 		want   string
 	}{
-		{`let x = 1;
+		{`using "io";
+		let x = 1;
 		x++;
-		println(x);`, "2\n"},
-		{`let y = 1;
+		io.println(x);`, "2\n"},
+		{`using "io";
+		let y = 1;
 		y--;
-		println(y);`, "0\n"},
-		{`let j = 1;
+		io.println(y);`, "0\n"},
+		{`using "io";
+		let j = 1;
 		j += 1;
-		println(j);`, "2\n"},
-		{`let k = 1;
+		io.println(j);`, "2\n"},
+		{`using "io";
+		let k = 1;
 		k -= 1;
-		println(k);`, "0\n"},
-		{`let i = 1;
+		io.println(k);`, "0\n"},
+		{`using "io";
+		let i = 1;
 		i *= 2;
-		println(i);`, "2\n"},
-		{`let n = 1;
+		io.println(i);`, "2\n"},
+		{`using "io";
+		let n = 1;
 		n /= 1;
-		println(n);`, "1\n"},
-		{`let m = 1;
+		io.println(n);`, "1\n"},
+		{`using "io";
+		let m = 1;
 		m %= 1;
-		println(m);`, "0\n"},
+		io.println(m);`, "0\n"},
 	}
 
 	for _, tt := range tests {

--- a/tests/while_test.go
+++ b/tests/while_test.go
@@ -17,20 +17,23 @@ func TestWhile(t *testing.T) {
 		want        string
 		throwsError bool
 	}{
-		{`let i = 0;
+		{`using "io";
+		let i = 0;
 		while (i < 5) {
-			println(i);
+			io.println(i);
 			i++;
 		}`, "0\n1\n2\n3\n4\n", false},
-		{`let j = 5;
+		{`using "io";
+		let j = 5;
 		while (j > 0) {
-			println(j);
+			io.println(j);
 			j--;
 		}`, "5\n4\n3\n2\n1\n", false},
-		{`let arr = [];
+		{`using "io";
+		let arr = [];
 		let k = 0;
 		while (k < 1) {
-			println(arr[k]);
+			io.println(arr[k]);
 			k++;
 		}`, "interpreter error: index out of bounds for index 0", true},
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -64,5 +64,5 @@ func StoB(s string) bool {
 // Language standard output writer.
 func Stdout(s string, buff io.Writer) {
 
-	fmt.Fprintln(buff, s)
+	fmt.Fprintf(buff, "%v", s)
 }


### PR DESCRIPTION
This PR adds:
- The concept of `Namespace`'s, which act as object containers for the Goblin std::lib. 
- The start of the `io` package, which currently contains `print`, `println`, and `printf` functions.
- Suite of tests for the `io` package
- Some bug fixes in the `parser` and `interpreter`