### PR TITLE
Std lib io implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,45 @@ A repository for the Goblin Programming Language.
 ```
 using "io";
 
+// print, a standard printing function.
+// io.print(msg string)
 io.print("Hello, World");
+
+// println - acts the same as print, but appends a new line to the end.
+// io.println(msg string)
 io.println("Hello, World");
+
+// printf - allows for formatted statements to be printed.
+// io.printf(formattedString string, args ...any)
 io.printf("Hello, %v", "World");
+
+// sprintf - allows for formatted statements to be printed.
+// io.sprintf(formattedString string, args ...any) string
 let x = io.sprintf("Hello, %v", "World");
+
+// input - reads a single line from std::in.
+// io.input(message string) string
+let userInput = os.input("Input: ")
+
+// open - returns a new file object using the specified mode, i.e. r, w, a.
+// io.open(fileName string, mode string) fileObject
+let f = io.open("path/to/file", "r")
+
+// close - closes the specified file object.
+// io.close(fileObject *fileObj)
+io.close(f)
+
+// read - reads a single line from the specified file.
+// io.readline(fileObject *fileObj, lineNumber int) string
+let line = io.readline(f, 1)
+
+// readline - reads a file line by line
+// io.readlines(fileObject *fileObj) []string
+let lines = io.readlines(f)
+
+// writen - writes the contents of the buffer to the specified fileObject.
+// io.write(fileObject *fileObj, buffer []byte)
+io.write(f, b"information")
 ```
 ## Language Design
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,17 @@
 
 A repository for the Goblin Programming Language.
 
-## Language Features
+## Standard Libary
+### `io`
+```
+using "io";
+
+io.print("Hello, World");
+io.println("Hello, World");
+io.printf("Hello, %v", "World");
+let x = io.sprintf("Hello, %v", "World");
+```
+## Language Design
 
 ### Variable decleration
 ```

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ let f = io.open("path/to/file", "r")
 // io.close(fileObject *fileObj)
 io.close(f)
 
-// read - reads a single line from the specified file.
+// readline - reads a single line from the specified file.
 // io.readline(fileObject *fileObj, lineNumber int) string
 let line = io.readline(f, 1)
 
-// readline - reads a file line by line
+// readlines - reads a file line by line
 // io.readlines(fileObject *fileObj) []string
 let lines = io.readlines(f)
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,8 @@ import (
 func main() {
 
 	env := runtime.Environment{
-		Stdout:     os.Stdout, // Set the stdout as os.stdout
+		Stdout:     os.Stdout,
+		Stdin:      os.Stdin,
 		Variables:  map[string]runtime.RuntimeValue{},
 		Constants:  map[string]bool{},
 		Namespaces: map[string]runtime.Namespace{},

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	program "goblin.org/main/program"
@@ -46,6 +47,9 @@ func main() {
 		}
 		defer file.Close()
 
+		// Since loading from source, point the entry point to containing folder.
+		env.EntryLocation = filepath.Dir(file.Name())
+
 		// Read the contents of the file.
 		content, err := os.ReadFile(executable)
 		if err != nil {
@@ -70,6 +74,15 @@ func main() {
 
 		// REPL Mode.
 		fmt.Println("Goblin v0.1")
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Println("Error getting current working directory:", err)
+			// Handle the error appropriately (e.g., exit)
+		}
+
+		// Set the Entry location to wherever the users terminal currently is.
+		env.EntryLocation = cwd
 
 		for {
 

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -10,12 +10,13 @@ var register = map[string]Namespace{
 }
 
 type Environment struct {
-	Parent     *Environment
-	Stdout     io.Writer
-	Stdin      io.Reader
-	Variables  map[string]RuntimeValue
-	Constants  map[string]bool
-	Namespaces map[string]Namespace
+	Parent        *Environment
+	Stdout        io.Writer
+	Stdin         io.Reader
+	EntryLocation string
+	Variables     map[string]RuntimeValue
+	Constants     map[string]bool
+	Namespaces    map[string]Namespace
 }
 
 // Used to declare a new variable. Includes checking for variable already existing.

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -12,6 +12,7 @@ var register = map[string]Namespace{
 type Environment struct {
 	Parent     *Environment
 	Stdout     io.Writer
+	Stdin      io.Reader
 	Variables  map[string]RuntimeValue
 	Constants  map[string]bool
 	Namespaces map[string]Namespace

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -13,6 +13,12 @@ import (
 /*
 TODO:
 - Arg count check, add error handling to check that all functions have the correct number of arguments specified, and that they are of the proper type.
+- Fix bug in open that occurs when specifying local file (files are local to interpreter/main.go, not local to the .gob source file)
+- Add new type: fileObject
+	- contains a reference to the specified file
+	- value that specifies the mode of the file (read, write, append)
+- Add new type: byte
+	- Similar to string, but is a collection of bytes
 */
 
 var IO = Namespace{
@@ -38,9 +44,25 @@ var IO = Namespace{
 			Type: "NativeFn",
 			Call: input,
 		},
-		"read": {
+		"readline": {
 			Type: "NativeFn",
-			Call: read,
+			Call: readline,
+		},
+		"readlines": {
+			Type: "NativeFn",
+			Call: readlines,
+		},
+		"open": {
+			Type: "NativeFn",
+			Call: open,
+		},
+		"close": {
+			Type: "NativeFn",
+			Call: close,
+		},
+		"write": {
+			Type: "NativeFn",
+			Call: write,
 		},
 	},
 }
@@ -64,7 +86,7 @@ var print FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValu
 	return MK_NULL(), nil
 }
 
-// println acts the same as print, but appends a new line to the end.
+// println - acts the same as print, but appends a new line to the end.
 // io.println(msg string)
 var println FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
@@ -83,7 +105,7 @@ var println FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVa
 	return MK_NULL(), nil
 }
 
-// printf allows for formatted statements to be printed.
+// printf - allows for formatted statements to be printed.
 // io.printf(formattedString string, args ...any)
 var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
@@ -103,8 +125,8 @@ var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVal
 	return MK_NULL(), nil
 }
 
-// sprintf allows for formatted statements to be printed.
-// io.sprintf(formattedString string, args ...any)
+// sprintf - allows for formatted statements to be printed.
+// io.sprintf(formattedString string, args ...any) string
 var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
 	numArgs := len(args)
@@ -120,8 +142,8 @@ var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVa
 	return MK_STRING(s), nil
 }
 
-// input reads a single line from std::in.
-// io.input(message string)
+// input - reads a single line from std::in.
+// io.input(message string) string
 var input FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
 	numArgs := len(args)
@@ -132,7 +154,7 @@ var input FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValu
 	m := args[0]
 	msg, isStr := m.(StringValue)
 	if !isStr {
-		return nil, fmt.Errorf("os.readline message must be string type, got %v", msg.Type)
+		return nil, fmt.Errorf("os.input message must be string type, got %v", msg.Type)
 	}
 
 	reader := bufio.NewReader(env.Stdin)
@@ -150,9 +172,23 @@ var input FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValu
 	return MK_STRING(input), nil
 }
 
-// read reads a single line from the specified file.
-// io.read(fileName string, lineNumber int)
-var read FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+// open - returns a new file object using the specified mode, i.e. r, w, a.
+// io.open(fileName string, mode string) fileObject
+var open FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	return nil, nil
+}
+
+// close - closes the specified file object.
+// io.close(fileObject *fileObj)
+var close FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	return nil, nil
+}
+
+// read - reads a single line from the specified file.
+// io.readline(fileObject *fileObj, lineNumber int) string
+var readline FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
 	numArgs := len(args)
 	if numArgs != 2 {
@@ -204,6 +240,20 @@ var read FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue
 	}
 
 	return nil, fmt.Errorf("line number %d not found in file", lineNumber)
+}
+
+// readline - reads a file line by line
+// io.readlines(fileObject *fileObj) []string
+var readlines FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	return nil, nil
+}
+
+// writen - writes the contents of the buffer to the specified fileObject.
+// io.write(fileObject *fileObj, buffer []byte)
+var write FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	return nil, nil
 }
 
 // Helper function for printf, sprintf.

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -49,6 +49,11 @@ var IO = Namespace{
 // io.print(msg string)
 var print FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
+	numArgs := len(args)
+	if numArgs != 1 {
+		return nil, fmt.Errorf("unexpected number of args for io.print, expected 1 got %v", numArgs)
+	}
+
 	str, err := printer(args)
 	if err != nil {
 		return nil, err
@@ -63,6 +68,11 @@ var print FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValu
 // io.println(msg string)
 var println FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
+	numArgs := len(args)
+	if numArgs != 1 {
+		return nil, fmt.Errorf("unexpected number of args for io.println, expected 1 got %v", numArgs)
+	}
+
 	str, err := printer(args)
 	if err != nil {
 		return nil, err
@@ -76,6 +86,11 @@ var println FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVa
 // printf allows for formatted statements to be printed.
 // io.printf(formattedString string, args ...any)
 var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	numArgs := len(args)
+	if numArgs < 1 {
+		return nil, fmt.Errorf("unexpected number of args for io.printf, expected min 1 got %v", numArgs)
+	}
 
 	s, err := printerFormatter(args)
 	if err != nil {
@@ -92,6 +107,11 @@ var printf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVal
 // io.sprintf(formattedString string, args ...any)
 var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
 
+	numArgs := len(args)
+	if numArgs < 1 {
+		return nil, fmt.Errorf("unexpected number of args for io.sprintf, expected min 1 got %v", numArgs)
+	}
+
 	s, err := printerFormatter(args)
 	if err != nil {
 		return nil, err
@@ -103,6 +123,11 @@ var sprintf FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeVa
 // input reads a single line from std::in.
 // io.input(message string)
 var input FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	numArgs := len(args)
+	if numArgs != 1 {
+		return nil, fmt.Errorf("unexpected number of args for io.input, expected 1 got %v", numArgs)
+	}
 
 	m := args[0]
 	msg, isStr := m.(StringValue)
@@ -128,6 +153,11 @@ var input FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValu
 // read reads a single line from the specified file.
 // io.read(fileName string, lineNumber int)
 var read FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	numArgs := len(args)
+	if numArgs != 2 {
+		return nil, fmt.Errorf("unexpected number of args for io.read, expected 2 got %v", numArgs)
+	}
 
 	f := args[0]
 	file, isStr := f.(StringValue)

--- a/runtime/io.go
+++ b/runtime/io.go
@@ -328,7 +328,7 @@ func fileReader(file FileObjectValue, lineNumber int) (string, error) {
 		return "\r\n", err
 	}
 
-	return "\r\n", nil
+	return "\r\n", fmt.Errorf("line number %v not found in %v", lineNumber, file.Path)
 }
 
 // Helper function for open

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -132,7 +132,7 @@ type FileObjectValue struct {
 	File          *os.File
 	Mode          int
 	IsOpen        bool
-	CursorPointer int
+	CursorPointer *int
 }
 
 func (f FileObjectValue) runtime() {}

--- a/runtime/values.go
+++ b/runtime/values.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"os"
 
 	"goblin.org/main/frontend/ast"
 )
@@ -9,13 +10,16 @@ import (
 type ValueType string
 
 const (
-	Number      ValueType = "Number"
-	Array       ValueType = "Array"
-	Map         ValueType = "Map"
-	Null        ValueType = "Null"
-	Boolean     ValueType = "Boolean"
-	String      ValueType = "String"
-	Object      ValueType = "Object"
+	// Types
+	Number     ValueType = "Number"
+	Array      ValueType = "Array"
+	Map        ValueType = "Map"
+	Null       ValueType = "Null"
+	Boolean    ValueType = "Boolean"
+	String     ValueType = "String"
+	Object     ValueType = "Object"
+	FileObject ValueType = "FileObject"
+
 	NativeFn    ValueType = "NativeFn"
 	UserFn      ValueType = "UserFn"
 	Conditional ValueType = "Contitional"
@@ -121,6 +125,17 @@ type WhileValue struct {
 }
 
 func (w WhileValue) runtime() {}
+
+type FileObjectValue struct {
+	Type          string
+	Path          string
+	File          *os.File
+	Mode          int
+	IsOpen        bool
+	CursorPointer int
+}
+
+func (f FileObjectValue) runtime() {}
 
 /* -- MACROS --*/
 

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,5 +1,8 @@
 using "io";
 let f = io.open("test.txt", "r");
-let line = io.readline(f, 2);
 
+let line = io.readline(f, 1);
 io.println(line);
+io.close(f);
+
+let anotherLine = io.readline(f, 1);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,5 +1,5 @@
 using "io";
 let f = io.open("test.txt", "r");
-let line = io.readline(f, 1);
+let line = io.readline(f, 2);
 
-io.println(f);
+io.println(line);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,8 +1,9 @@
 using "io";
 let f = io.open("test.txt", "r");
 
-let line = io.readline(f, 1);
-io.println(line);
-io.close(f);
+for(let i = 1; i < 3; i++;){
 
-let anotherLine = io.readline(f, 1);
+    let line = io.readlines(f);
+
+    io.println(line);
+}

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,4 +1,3 @@
 using "io";
 
-let x = io.read("/test.txt", 2);
-io.println(x);
+io.printf();

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,3 +1,3 @@
 using "io";
-
-io.printf();
+let i = io.input("Message: ");
+io.print(i);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,4 +1,4 @@
 using "io";
 
-let x = io.sprintf("Hello, %v", "World");
+let x = io.read("/test.txt", 2);
 io.println(x);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,3 +1,5 @@
 using "io";
-let i = io.input("Message: ");
-io.print(i);
+let f = io.open("test.txt", "r");
+let line = io.readline(f, 1);
+
+io.println(f);

--- a/source/test.txt
+++ b/source/test.txt
@@ -1,2 +1,2 @@
-This is a line!
-This is another line!
+Hello, World!
+This is a test!

--- a/source/test.txt
+++ b/source/test.txt
@@ -1,2 +1,2 @@
-Hello, World
+Hello, World!
 This is a test

--- a/source/test.txt
+++ b/source/test.txt
@@ -1,0 +1,2 @@
+This is a line!
+This is another line!

--- a/source/test.txt
+++ b/source/test.txt
@@ -1,2 +1,2 @@
-Hello, World!
-This is a test!
+Hello, World
+This is a test

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -7,7 +7,7 @@ import (
 	"goblin.org/main/runtime"
 )
 
-// Mock up the stdout buffer using the below byte buffer.
+// Mock std::out buffer using the below byte buffer.
 var output bytes.Buffer
 
 var env = runtime.Environment{}

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"os"
 
 	"goblin.org/main/runtime"
 )
@@ -15,6 +16,7 @@ var env = runtime.Environment{}
 func HarnessSetup() {
 	output = bytes.Buffer{}
 	env.Stdout = &output
+	env.Stdin = os.Stdin
 	env.Variables = map[string]runtime.RuntimeValue{}
 	env.Constants = map[string]bool{}
 	env.Namespaces = map[string]runtime.Namespace{}

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -20,6 +20,7 @@ func HarnessSetup() {
 	env.Variables = map[string]runtime.RuntimeValue{}
 	env.Constants = map[string]bool{}
 	env.Namespaces = map[string]runtime.Namespace{}
+	env.EntryLocation = "../source"
 
 	env.Setup()
 }

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -46,6 +46,10 @@ func TestPrint(t *testing.T) {
 
 			io.print(map[keys[i]]);
 		}`, "123", false},
+		{`using "io";
+		io.print();`, "interpreter error: unexpected number of args for io.print, expected 1 got 0", true},
+		{`using "io";
+		io.print("hello", "world");`, "interpreter error: unexpected number of args for io.print, expected 1 got 2", true},
 	}
 
 	for _, tt := range tests {
@@ -117,6 +121,10 @@ func TestPrintln(t *testing.T) {
 
 			io.println(map[keys[i]]);
 		}`, "1\n2\n3\n", false},
+		{`using "io";
+		io.println();`, "interpreter error: unexpected number of args for io.println, expected 1 got 0", true},
+		{`using "io";
+		io.println("hello", "world");`, "interpreter error: unexpected number of args for io.println, expected 1 got 2", true},
 	}
 
 	for _, tt := range tests {
@@ -164,6 +172,8 @@ func TestPrintf(t *testing.T) {
 		{`using "io";
 		let arr = [1, 2, 3];
 		io.printf("One: %v", arr[0]);`, "One: 1", false},
+		{`using "io";
+		io.printf();`, "interpreter error: unexpected number of args for io.printf, expected min 1 got 0", true},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +218,53 @@ func TestSPrintf(t *testing.T) {
 	}{
 		{`using "io";
 		let i = io.sprintf("Hello, %v", "World");
+		io.print(i);`, "Hello, World", false},
+		{`using "io";
+		let j = io.sprintf();`, "interpreter error: unexpected number of args for io.sprintf, expected min 1 got 0", true},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}
+
+func TestInput(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		let i = io.input("Hello, %v", "World");
 		io.print(i);`, "Hello, World", false},
 	}
 

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -423,3 +423,112 @@ func TestReadLine(t *testing.T) {
 		})
 	}
 }
+
+func TestReadLines(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		let f = io.open("test.txt", "r");
+		let line = io.readline(f, 1);
+		io.print(line);`, "Hello, World!", false},
+		{`using "io";
+		let fr = io.open("test.txt", "r");
+		let liner = io.readline(fr, 3);
+		io.print(liner);`, "interpreter error: line number 3 not found in ../source/test.txt", true},
+		{`using "io";
+		let fw = io.open("test.txt", "w");
+		let linew = io.readline(fw, 1);
+		io.print(linew);`, "interpreter error: file: ../source/test.txt not opened in a valid read-mode", true},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf("%v - %v", err.Error(), output.String())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}
+
+func TestClose(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		let f = io.open("test.txt", "r");
+
+		let line = io.readline(f, 1);
+		io.println(line);
+		io.close(f);
+
+		let anotherLine = io.readline(f, 1);`, "interpreter error: read ../source/test.txt: file already closed", true},
+		{`using "io";
+		let file = io.open("test.txt", "r");
+
+		let lline = io.readline(file, 1);
+		io.println(lline);`, "Hello, World\n", false},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf("%v - %v", err.Error(), output.String())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}

--- a/tests/io_test.go
+++ b/tests/io_test.go
@@ -433,20 +433,7 @@ func TestReadLines(t *testing.T) {
 		source      string
 		want        string
 		throwsError bool
-	}{
-		{`using "io";
-		let f = io.open("test.txt", "r");
-		let line = io.readline(f, 1);
-		io.print(line);`, "Hello, World!", false},
-		{`using "io";
-		let fr = io.open("test.txt", "r");
-		let liner = io.readline(fr, 3);
-		io.print(liner);`, "interpreter error: line number 3 not found in ../source/test.txt", true},
-		{`using "io";
-		let fw = io.open("test.txt", "w");
-		let linew = io.readline(fw, 1);
-		io.print(linew);`, "interpreter error: file: ../source/test.txt not opened in a valid read-mode", true},
-	}
+	}{}
 
 	for _, tt := range tests {
 		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
@@ -500,7 +487,7 @@ func TestClose(t *testing.T) {
 		let file = io.open("test.txt", "r");
 
 		let lline = io.readline(file, 1);
-		io.println(lline);`, "Hello, World\n", false},
+		io.println(lline);`, "Hello, World!\n", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds the following:
- Start of the `io` stdlib package, including the following functions:
  - `print`
  - `println`
  - `printf`
  - `sprintf`
  - `input`
  - `open`
  - `close`
  - `readline`
  - `readlines` `(stub)`
  - `write` `(stub)`
- Tests for the above (implemented) functions