### PR TITLE
Strings std lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ A repository for the Goblin Programming Language.
 
 ## Standard Libary
 
+### `strings`
+```
+using "data";
+
+// split, splits string `s` by delimiter `d`, returns an array of sub-string elements.
+// strings.split(s str, d str)
+strings.split("Hello World", " ");
+```
+
 ### `data`
 ```
 using "data";

--- a/runtime/env.go
+++ b/runtime/env.go
@@ -6,8 +6,9 @@ import (
 )
 
 var register = map[string]Namespace{
-	"io":   IO,
-	"data": Data,
+	"io":      IO,
+	"data":    Data,
+	"strings": Strings,
 }
 
 type Environment struct {

--- a/runtime/strings.go
+++ b/runtime/strings.go
@@ -1,0 +1,48 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+)
+
+var Strings = Namespace{
+	Name: "data",
+	Functions: map[string]NativeFunction{
+		"split": {
+			Type: "NativeFn",
+			Call: split,
+		},
+	},
+}
+
+// split, splits string `s` by delimiter `d`, returns an array of sub-string elements.
+// strings.split(s str, d str)
+var split FunctionCall = func(args []RuntimeValue, env Environment) (RuntimeValue, error) {
+
+	numArgs := len(args)
+	if numArgs != 2 {
+		return nil, fmt.Errorf("unexpected number of args for strings.split, expected 2 got %v", numArgs)
+	}
+
+	s := args[0]
+	str, isStr := s.(StringValue)
+	if !isStr {
+		return nil, fmt.Errorf("strings.split must be used on string type, %v type given", str.Type)
+	}
+
+	d := args[1]
+	del, isStr := d.(StringValue)
+	if !isStr {
+		return nil, fmt.Errorf("strings.split delimiter must be string type, %v type given", del.Type)
+	}
+
+	splits := strings.Split(str.Value, del.Value)
+
+	sRuntime := make([]RuntimeValue, 0)
+	for _, st := range splits {
+
+		sRuntime = append(sRuntime, StringValue{Value: st, Type: "StringValue"})
+	}
+
+	return MK_ARRAY(sRuntime), nil
+}

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,8 +1,3 @@
-using "data";
-using "io";
+using "strings";
 
-let arr = [];
-let last = data.pop(arr, 1);
-
-io.println(last);
-io.println(arr);
+let words = strings.split("Hello, world");

--- a/tests/strings_test.go
+++ b/tests/strings_test.go
@@ -1,0 +1,85 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"goblin.org/main/program"
+)
+
+func TestSplit(t *testing.T) {
+
+	// Setup the program env.
+	HarnessSetup()
+
+	var tests = []struct {
+		source      string
+		want        string
+		throwsError bool
+	}{
+		{`using "io";
+		using "strings";
+
+		let words = strings.split("Hello world", " ");
+		io.print(words[0]);`, "Hello", false},
+		{`using "io";
+		using "data";
+		using "strings";
+
+		let wordss = strings.split("Hello world", " ");
+		let count = data.size(wordss);
+
+		io.print(count);`, "2", false},
+		{`using "io";
+		using "data";
+		using "strings";
+
+		let source = "Hello world this is a test";
+		let wordsss = strings.split(source, " ");
+		let size = data.size(wordsss);
+
+		for(let i = 0; i < size; i++;){
+
+			io.print(wordsss[i]);
+		}`, "Helloworldthisisatest", false},
+		{`using "io";
+		using "strings";
+
+		let words = strings.split("Hello world");
+		io.print(words[0]);`, "interpreter error: unexpected number of args for strings.split, expected 2 got 1", true},
+		{`using "io";
+		using "strings";
+
+		let words = strings.split("Hello world", ",", "");
+		io.print(words[0]);`, "interpreter error: unexpected number of args for strings.split, expected 2 got 3", true},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%v, %v", tt.source, tt.want)
+		t.Run(testname, func(t *testing.T) {
+
+			// Run the program.
+			_, err := program.Run(string(tt.source), env)
+
+			if !tt.throwsError {
+
+				// When tests aren't supposed to throw an error.
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+
+				if output.String() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
+				}
+			} else {
+
+				// When tests are supposed to throw an error.
+				if err.Error() != tt.want {
+					t.Errorf("expected `%v`, received `%v`", tt.want, err.Error())
+				}
+			}
+
+			FlushBuffer()
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new standard library Namespace, `strings`. The `strings` Namespace contains (for the moment) a single built in function:
- `split`, used to split a string by a specified delimiter to create a new array object.

E.g:

```
using "strings";
let words = strings.split("Hello World", " ");
```
Produces the following: `["Hello", "World"]`