### PR TITLE
Debug improvements adding line numbers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ io.write(f, b"information")
 ```
 ## Language Design
 
+### Error handling
+Support for front-end error handling at the parser level. For example:
+```
+let x = 10
+```
+Yields the following:
+```
+parse error: let x = 10
+             ~~~~~~~~~~^
+expecting token `;` on line 1 col 10
+```
+
 ### Variable decleration
 ```
 let x = 10;

--- a/frontend/lexer/lexer.go
+++ b/frontend/lexer/lexer.go
@@ -14,40 +14,61 @@ func Tokenize(sourceCode string) []Token {
 
 	src := strings.Split(sourceCode, "")
 
+	line := 1
+	col := 0
+
 	for len(src) > 0 {
 
+		if src[0] == "\n" {
+			line++
+			col = 0
+		}
+		if src[0] == " " {
+			col++
+		}
+
 		if src[0] == "(" {
-			tokens = append(tokens, token(OpenParen, utils.Shift[string](&src)))
+			tokens = append(tokens, token(OpenParen, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == ")" {
-			tokens = append(tokens, token(CloseParen, utils.Shift[string](&src)))
+			tokens = append(tokens, token(CloseParen, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "{" {
-			tokens = append(tokens, token(OpenBrace, utils.Shift[string](&src)))
+			tokens = append(tokens, token(OpenBrace, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "}" {
-			tokens = append(tokens, token(CloseBrace, utils.Shift[string](&src)))
+			tokens = append(tokens, token(CloseBrace, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "[" {
-			tokens = append(tokens, token(OpenBracket, utils.Shift[string](&src)))
+			tokens = append(tokens, token(OpenBracket, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "]" {
-			tokens = append(tokens, token(CloseBracket, utils.Shift[string](&src)))
+			tokens = append(tokens, token(CloseBracket, utils.Shift[string](&src), line, col))
+			col++
 
 		} else if src[0] == "+" {
 
 			if (src[1] == "+") || (src[1] == "=") {
 				// Shorthand ++ or +=
 				op := fmt.Sprintf("%v%v", utils.Shift[string](&src), utils.Shift[string](&src))
-				tokens = append(tokens, token(ShorthandOperator, op))
+				tokens = append(tokens, token(ShorthandOperator, op, line, col))
+				col += 2
 			} else {
 				// Standard + BinOp.
-				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src)))
+				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src), line, col))
+				col++
 			}
 		} else if src[0] == "-" {
 
 			if (src[1] == "-") || (src[1] == "=") {
 				// Shorthand -- or -=
 				op := fmt.Sprintf("%v%v", utils.Shift[string](&src), utils.Shift[string](&src))
-				tokens = append(tokens, token(ShorthandOperator, op))
+				tokens = append(tokens, token(ShorthandOperator, op, line, col))
+				col += 2
 			} else {
 				// Standard - BinOp.
-				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src)))
+				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src), line, col))
+				col++
 			}
 		} else if src[0] == "/" || src[0] == "*" || src[0] == "%" {
 
@@ -55,25 +76,34 @@ func Tokenize(sourceCode string) []Token {
 			if src[1] == "=" {
 				// Shorthand operator.
 				op := fmt.Sprintf("%v%v", utils.Shift[string](&src), utils.Shift[string](&src))
-				tokens = append(tokens, token(ShorthandOperator, op))
+				tokens = append(tokens, token(ShorthandOperator, op, line, col))
+				col += 2
 			} else {
 				// Standard BinOp.
-				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src)))
+				tokens = append(tokens, token(BinaryOperator, utils.Shift[string](&src), line, col))
+				col++
 			}
 		} else if src[0] == ">" || src[0] == "<" {
-			tokens = append(tokens, token(ConditionalOperator, utils.Shift[string](&src)))
+			tokens = append(tokens, token(ConditionalOperator, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "=" && src[1] != "=" {
-			tokens = append(tokens, token(Equals, utils.Shift[string](&src)))
+			tokens = append(tokens, token(Equals, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == ";" {
-			tokens = append(tokens, token(EOL, utils.Shift[string](&src)))
+			tokens = append(tokens, token(EOL, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == ":" {
-			tokens = append(tokens, token(Colon, utils.Shift[string](&src)))
+			tokens = append(tokens, token(Colon, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "," {
-			tokens = append(tokens, token(Comma, utils.Shift[string](&src)))
+			tokens = append(tokens, token(Comma, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "." {
-			tokens = append(tokens, token(Period, utils.Shift[string](&src)))
+			tokens = append(tokens, token(Period, utils.Shift[string](&src), line, col))
+			col++
 		} else if src[0] == "?" {
-			tokens = append(tokens, token(Ternary, utils.Shift[string](&src)))
+			tokens = append(tokens, token(Ternary, utils.Shift[string](&src), line, col))
+			col++
 		} else {
 
 			// Multicharacter tokens (<=, >=...)
@@ -84,7 +114,8 @@ func Tokenize(sourceCode string) []Token {
 				symbol := utils.Shift[string](&src)
 				symbol += utils.Shift[string](&src)
 
-				tokens = append(tokens, token(Equality, symbol))
+				tokens = append(tokens, token(Equality, symbol, line, col))
+				col += 2
 
 			} else if isInt(src[0]) {
 				// Builds a number token.
@@ -94,7 +125,8 @@ func Tokenize(sourceCode string) []Token {
 					num += utils.Shift[string](&src)
 				}
 
-				tokens = append(tokens, token(Number, num))
+				tokens = append(tokens, token(Number, num, line, col))
+				col += len(num)
 
 			} else if isQuote(src[0]) {
 
@@ -112,7 +144,8 @@ func Tokenize(sourceCode string) []Token {
 				// Shift past '"'.
 				utils.Shift[string](&src)
 
-				tokens = append(tokens, token(String, str))
+				tokens = append(tokens, token(String, str, line, col))
+				col += (len(str) + 2) // Lenght of string + 2 for the quotes either side.
 
 			} else if isAlpha(src[0]) {
 				// Builds an identifier token.
@@ -129,14 +162,18 @@ func Tokenize(sourceCode string) []Token {
 					// If not exist, check to see is this is a bool value.
 					bVal, err := truthValue(iden)
 					if err == nil {
-						tokens = append(tokens, token(Boolean, utils.BtoS(bVal)))
+						bsv := utils.BtoS(bVal)
+						tokens = append(tokens, token(Boolean, bsv, line, col))
+						col += len(bsv)
 					} else {
 
 						// Really is an identifier.
-						tokens = append(tokens, token(Identifier, iden))
+						tokens = append(tokens, token(Identifier, iden, line, col))
+						col += len(iden)
 					}
 				} else {
-					tokens = append(tokens, token(t, iden))
+					tokens = append(tokens, token(t, iden, line, col))
+					col += len(iden)
 				}
 
 			} else if isSkippable(src[0]) {
@@ -150,7 +187,7 @@ func Tokenize(sourceCode string) []Token {
 	}
 
 	// Add in the EOF token.
-	tokens = append(tokens, token(EOF, "EOF"))
+	tokens = append(tokens, token(EOF, "EOF", line, col))
 
 	return tokens
 }
@@ -198,11 +235,13 @@ func isSkippable(src string) bool {
 }
 
 // Builds and returns a new token.
-func token(tknType TokenType, value string) Token {
+func token(tknType TokenType, value string, line int, col int) Token {
 
 	token := Token{
 		Type:  tknType,
 		Value: value,
+		Line:  line,
+		Col:   col,
 	}
 
 	return token

--- a/frontend/lexer/lexer.go
+++ b/frontend/lexer/lexer.go
@@ -22,14 +22,19 @@ func Tokenize(sourceCode string) ([]Token, map[int]string) {
 	for len(src) > 0 {
 
 		if src[0] == "\n" {
-			// Capture the line we just lexed.
-			audit[line] = auditBuilder
+
+			// Only capture a line if there is anything there.
+			if auditBuilder != "" {
+
+				// Capture the line we just lexed.
+				audit[line] = auditBuilder
+
+				// Increment the line count.
+				line++
+			}
 
 			// Reset the builder
 			auditBuilder = ""
-
-			// Increment the line count.
-			line++
 
 			// Reset the col counter.
 			col = 0
@@ -180,7 +185,7 @@ func Tokenize(sourceCode string) ([]Token, map[int]string) {
 
 				tokens = append(tokens, token(String, str, line, col))
 				auditBuilder += str
-				col += (len(str) + 2) // Lenght of string + 2 for the quotes either side.
+				col += (len(str) + 2) // Length of string + 2 for the quotes either side.
 
 			} else if isAlpha(src[0]) {
 				// Builds an identifier token.

--- a/frontend/lexer/token.go
+++ b/frontend/lexer/token.go
@@ -34,18 +34,18 @@ const (
 	String     TokenType = "String"
 
 	// Symbols.
-	Equals       TokenType = "Equals"
-	OpenParen    TokenType = "OpenParen"
-	CloseParen   TokenType = "CloseParen"
-	Comma        TokenType = "Comma"
-	Colon        TokenType = "Colon"
-	OpenBrace    TokenType = "OpenBrace"
-	CloseBrace   TokenType = "CloseBrace"
-	OpenBracket  TokenType = "OpenBracket"
-	CloseBracket TokenType = "CloseBracket"
-	Period       TokenType = "Period"
-	Equality     TokenType = "Equality"
-	Ternary      TokenType = "Ternary"
+	Equals       TokenType = "="
+	OpenParen    TokenType = "("
+	CloseParen   TokenType = ")"
+	Comma        TokenType = ","
+	Colon        TokenType = ":"
+	OpenBrace    TokenType = "{"
+	CloseBrace   TokenType = "}"
+	OpenBracket  TokenType = "["
+	CloseBracket TokenType = "]"
+	Period       TokenType = "."
+	Equality     TokenType = "=="
+	Ternary      TokenType = "?"
 
 	// Operators.
 	BinaryOperator      TokenType = "BinaryOperator"      // e.g. '+, -, /, *, etc'
@@ -63,7 +63,7 @@ const (
 	Using TokenType = "Using"
 
 	// End of Line.
-	EOL TokenType = "EOL"
+	EOL TokenType = ";"
 	// End of file.
 	EOF TokenType = "EOF"
 )

--- a/frontend/lexer/token.go
+++ b/frontend/lexer/token.go
@@ -5,6 +5,8 @@ import "fmt"
 type Token struct {
 	Type  TokenType
 	Value string
+	Line  int
+	Col   int
 }
 
 type Tokens []Token

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -55,12 +55,10 @@ func expect(t lexer.TokenType) (lexer.Token, error) {
 	return prev, nil
 }
 
-func ProduceAST(source string) (ast.Program, error) {
+func ProduceAST(t []lexer.Token, a map[int]string) (ast.Program, error) {
 
-	// Convert source code into tokens.
-	tokens, audit = lexer.Tokenize(source)
-
-	// fmt.Printf("Tokens: %v\n", tokens)
+	tokens = t
+	audit = a
 
 	program := ast.Program{
 		Kind: "Program",

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -34,8 +34,9 @@ func at() lexer.Token {
 func eat() lexer.Token {
 
 	// prev := utils.Shift[lexer.Token](&tokens)
+	prev := at()
 	tokenPointer++
-	return at()
+	return prev
 }
 
 // Returns the current token and shifts the pointer along to
@@ -63,7 +64,6 @@ func ErrorGenerator(message string) error {
 	m := utils.GenerateParserError(audit[tmp.Line], tmp.Value, tmp.Line, tmp.Col, message)
 
 	return fmt.Errorf("%v", m)
-
 }
 
 func ProduceAST(t []lexer.Token, a map[int]string) (ast.Program, error) {
@@ -1273,14 +1273,11 @@ func parse_primary_expression() (ast.Expression, error) {
 
 	default:
 		message := fmt.Sprintf("unexpected token found during parsing '%v'", at().Value)
-		tmp := tokens[tokenPointer-1]
-		formattedError := utils.GenerateParserError(audit[at().Line], tmp.Value, at().Line, at().Col, message)
-
-		return ast.Expr{}, fmt.Errorf("%v", formattedError)
+		return ast.Expr{}, fmt.Errorf("%v", ErrorGenerator(message))
 	}
 }
 
 // Checks to see if we have hit the end of the file.
 func notEof() bool {
-	return tokens[0].Type != lexer.EOF
+	return tokens[tokenPointer].Type != lexer.EOF
 }

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -54,7 +54,7 @@ func ProduceAST(source string) (ast.Program, error) {
 	// Convert source code into tokens.
 	tokens = lexer.Tokenize(source)
 
-	// fmt.Printf("Tokens: %v\n", tokens)
+	fmt.Printf("Tokens: %v\n", tokens)
 
 	program := ast.Program{
 		Kind: "Program",

--- a/frontend/parser/parser.go
+++ b/frontend/parser/parser.go
@@ -33,7 +33,6 @@ func at() lexer.Token {
 // the next in the list.
 func eat() lexer.Token {
 
-	// prev := utils.Shift[lexer.Token](&tokens)
 	prev := at()
 	tokenPointer++
 	return prev
@@ -45,12 +44,11 @@ func eat() lexer.Token {
 func expect(t lexer.TokenType) (lexer.Token, error) {
 
 	prev := at()
-	// this := utils.Shift[lexer.Token](&tokens)
 
 	if &prev == nil || prev.Type != t {
 
 		message := fmt.Sprintf("expecting token `%v`", t)
-		return lexer.Token{}, fmt.Errorf("%v", ErrorGenerator(message))
+		return lexer.Token{}, fmt.Errorf("%v", message)
 	}
 
 	return eat(), nil
@@ -68,12 +66,14 @@ func ErrorGenerator(message string) error {
 
 func ProduceAST(t []lexer.Token, a map[int]string) (ast.Program, error) {
 
+	// Setup & store the list of tokans.
 	tokens = make([]lexer.Token, 0)
 	tokens = append(tokens, t...)
 
-	audit = make(map[int]string, 0)
+	// Capture the audit trail of tokens.
 	audit = a
 
+	// Set token stack pointer to zero.
 	tokenPointer = 0
 
 	program := ast.Program{
@@ -85,7 +85,7 @@ func ProduceAST(t []lexer.Token, a map[int]string) (ast.Program, error) {
 
 		parsed_statement, err := parse_statement()
 		if err != nil {
-			return ast.Program{}, err
+			return ast.Program{}, ErrorGenerator(err.Error())
 		}
 
 		program.Body = append(program.Body, parsed_statement)
@@ -1278,7 +1278,7 @@ func parse_primary_expression() (ast.Expression, error) {
 
 	default:
 		message := fmt.Sprintf("unexpected token found during parsing '%v'", at().Value)
-		return ast.Expr{}, fmt.Errorf("%v", ErrorGenerator(message))
+		return ast.Expr{}, fmt.Errorf("%v", message)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 			// Only really want to print to console if its a statement that needs returning.
 			if result != nil {
 				r := fmt.Sprintf("%v", result)
+				fmt.Printf("Debug: %v\n", result)
 				utils.Stdout(r, env.Stdout)
 			}
 		}

--- a/program/run.go
+++ b/program/run.go
@@ -15,7 +15,7 @@ func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 	// Stage 1. Lex the input.
 	tokens, audit := lexer.Tokenize(input)
 
-	// fmt.Printf("Tokens: %v\n\n", tokens)
+	// fmt.Printf("Audit: %v\nTokens: %v\n", audit, tokens)
 
 	// Stage 2. Produce the Abstract Syntax Tree.
 	program, err := parser.ProduceAST(tokens, audit)
@@ -23,11 +23,15 @@ func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 		return nil, fmt.Errorf("parse error: %v", err.Error())
 	}
 
+	// fmt.Printf("Program: %v\n", program)
+
 	// Stage 3. Interprete the AST.
 	evaluation, err := runtime.Evaluate(program, env)
 	if err != nil {
 		return nil, fmt.Errorf("interpreter error: %v", err.Error())
 	}
+
+	// fmt.Printf("Eval: %v\n\n", evaluation)
 
 	if f, isNum := evaluation.(runtime.NativeFunction); isNum {
 

--- a/program/run.go
+++ b/program/run.go
@@ -15,7 +15,7 @@ func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 	// Stage 1. Lex the input.
 	tokens, audit := lexer.Tokenize(input)
 
-	fmt.Printf("Tokens: %v\n\n", tokens)
+	// fmt.Printf("Tokens: %v\n\n", tokens)
 
 	// Stage 2. Produce the Abstract Syntax Tree.
 	program, err := parser.ProduceAST(tokens, audit)

--- a/program/run.go
+++ b/program/run.go
@@ -3,6 +3,7 @@ package program
 import (
 	"fmt"
 
+	"goblin.org/main/frontend/lexer"
 	"goblin.org/main/frontend/parser"
 	runtime "goblin.org/main/runtime"
 	"goblin.org/main/utils"
@@ -11,11 +12,20 @@ import (
 // Where the source goes to be lexed, parsed, interpreted, and returned.
 func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 
-	program, err := parser.ProduceAST(input)
+	// Stage 1. Lex the input.
+	tokens, audit := lexer.Tokenize(input)
+
+	fmt.Printf("Audit: %v\n\n", audit)
+
+	// Stage 2. Produce the Abstract Syntax Tree.
+	program, err := parser.ProduceAST(tokens, audit)
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %v", err.Error())
 	}
 
+	fmt.Printf("Program: %v\n\n", program.Body)
+
+	// Stage 3. Interprete the AST.
 	evaluation, err := runtime.Evaluate(program, env)
 	if err != nil {
 		return nil, fmt.Errorf("interpreter error: %v", err.Error())

--- a/program/run.go
+++ b/program/run.go
@@ -15,15 +15,13 @@ func Run(input string, env runtime.Environment) (runtime.RuntimeValue, error) {
 	// Stage 1. Lex the input.
 	tokens, audit := lexer.Tokenize(input)
 
-	fmt.Printf("Audit: %v\n\n", audit)
+	fmt.Printf("Tokens: %v\n\n", tokens)
 
 	// Stage 2. Produce the Abstract Syntax Tree.
 	program, err := parser.ProduceAST(tokens, audit)
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %v", err.Error())
 	}
-
-	fmt.Printf("Program: %v\n\n", program.Body)
 
 	// Stage 3. Interprete the AST.
 	evaluation, err := runtime.Evaluate(program, env)

--- a/source/source.gob
+++ b/source/source.gob
@@ -2,3 +2,4 @@ using "io";
 using "data";
 
 let arr = [];
+let size = data.size(arr, 1);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,3 +1,3 @@
-using "strings";
+using "io";
 
-let words = strings.split("Hello, world");
+let x = 0;

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,5 +1,4 @@
 using "io";
 using "data";
 
-let arr = [];
-let size = data.size(arr, 1);
+let arr = [1, 2, 3]

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,4 +1,5 @@
 using "io";
-using "data";
 
-let arr = [1, 2, 3]
+let arr = [1, 2, 3];
+
+io.println(arr[0])

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,5 +1,5 @@
 using "io";
 
-if (10 > 5){
-    io.print(10);
-}
+let x = [1, 2, 3];
+
+io.println(x[2]);

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,5 +1,5 @@
 using "io";
 
-let arr = [1, 2, 3];
-
-io.println(arr[0])
+if (10 > 5){
+    io.print(10);
+}

--- a/source/source.gob
+++ b/source/source.gob
@@ -1,3 +1,4 @@
 using "io";
+using "data";
 
-let x = 0;
+let arr = [];

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -26,5 +26,5 @@ func HarnessSetup() {
 }
 
 func FlushBuffer() {
-	output = bytes.Buffer{}
+	output.Reset()
 }

--- a/tests/if_test.go
+++ b/tests/if_test.go
@@ -51,7 +51,6 @@ func TestSimpleIfCondition(t *testing.T) {
 				t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
 			}
 
-			fmt.Printf("Output buffer: %v\n", env.Stdout)
 			FlushBuffer()
 		})
 	}

--- a/tests/if_test.go
+++ b/tests/if_test.go
@@ -17,13 +17,13 @@ func TestSimpleIfCondition(t *testing.T) {
 		want   string
 	}{
 		{`using "io";
-		if (10 > 5){
-			io.println(10);
-		}`, "10\n"},
-		{`using "io";
 		if (10 < 20){
-			io.println(11);
-		}`, "11\n"},
+			io.print(11);
+		}`, "11"},
+		{`using "io";
+		if (10 > 5){
+			io.print(10);
+		}`, "10"},
 		{`using "io";
 		if (10 == 10){
 			io.println(10);
@@ -51,6 +51,7 @@ func TestSimpleIfCondition(t *testing.T) {
 				t.Errorf("expected `%v`, received `%v`", tt.want, output.String())
 			}
 
+			fmt.Printf("Output buffer: %v\n", env.Stdout)
 			FlushBuffer()
 		})
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,10 +21,10 @@ func Shift[T any](slice *[]T) T {
 
 // Converts a string into a number.
 func ToNumber(str string) (int, error) {
+
 	num, err := strconv.Atoi(str)
 	if err != nil {
-		fmt.Println("Error:", err)
-		return 0, fmt.Errorf("could not convert %v to int", str)
+		return 0, fmt.Errorf("could not convert `%v` to int", str)
 	}
 
 	return num, nil
@@ -74,22 +74,25 @@ parse error: using io
              ~~~~~~~~^
 expecting 'EOL' on line 1 col 10
 */
-func GenerateFormattedError(line string, col int, origin string) string {
+func GenerateParserError(auditLine string, specificToken string, line int, col int, message string) string {
 
-	underline := ""
+	origin := "parse error:"
+	underlines := ""
 
-	for i := 0; i < len(origin); i++ {
-		underline += " "
+	for i := 0; i < len(origin)+1; i++ {
+		underlines += " "
 	}
 
-	for i := 0; i < len(line)+1; i++ {
+	for i := 0; i < len(auditLine)+1; i++ {
 
-		if i == col {
-			underline += "^"
+		if i == (col + (len(specificToken))) {
+			underlines += "^"
 		} else {
-			underline += "~"
+			underlines += "~"
 		}
 	}
 
-	return underline
+	msg := fmt.Sprintf("%v\n%v\n%v on line %v col %v", auditLine, underlines, message, line, col)
+
+	return msg
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,10 +76,10 @@ expecting 'EOL' on line 1 col 10
 */
 func GenerateParserError(auditLine string, specificToken string, line int, col int, message string) string {
 
-	origin := "parse error:"
+	origin := "parse error: "
 	underlines := ""
 
-	for i := 0; i < len(origin)+1; i++ {
+	for i := 0; i < len(origin); i++ {
 		underlines += " "
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -66,3 +66,30 @@ func Stdout(s string, buff io.Writer) {
 
 	fmt.Fprintf(buff, "%v", s)
 }
+
+// Formats an error string to help with debugging.
+/*
+i.e.
+parse error: using io
+             ~~~~~~~~^
+expecting 'EOL' on line 1 col 10
+*/
+func GenerateFormattedError(line string, col int, origin string) string {
+
+	underline := ""
+
+	for i := 0; i < len(origin); i++ {
+		underline += " "
+	}
+
+	for i := 0; i < len(line)+1; i++ {
+
+		if i == col {
+			underline += "^"
+		} else {
+			underline += "~"
+		}
+	}
+
+	return underline
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -85,14 +85,14 @@ func GenerateParserError(auditLine string, specificToken string, line int, col i
 
 	for i := 0; i < len(auditLine)+1; i++ {
 
-		if i == (col + (len(specificToken))) {
+		if i == (col + len(specificToken)) {
 			underlines += "^"
 		} else {
 			underlines += "~"
 		}
 	}
 
-	msg := fmt.Sprintf("%v\n%v\n%v on line %v col %v", auditLine, underlines, message, line, col)
+	msg := fmt.Sprintf("%v\n%v\n%v on line %v col %v", auditLine, underlines, message, line, col+len(specificToken))
 
 	return msg
 }


### PR DESCRIPTION
This PR adds support for front-end error handling at the parser level.
For example:
```
let x = 10
```
Yields the following:
```
parse error: let x = 10
             ~~~~~~~~~~^
expecting token `;` on line 1 col 10
```